### PR TITLE
updates

### DIFF
--- a/monitoring/avimetrics script/README.md
+++ b/monitoring/avimetrics script/README.md
@@ -18,7 +18,7 @@ This repository includes that necessary files to deploy a centralized metrics sc
     - **appdynamics_http.json**:  This file contains values required to send to a App Dynamics Standalone Machine Agent HTTP Listener
     - **datadog.json**:  This file contains the values required to send to the Datadog HTTP API
     - **graphite_host.json**:  This file contains the graphite host and tcp port information
-    - **splunk_host.json**:  This file contains the values required to send to a Splunk HTTP Endpoint Collector API to a Metric Index
+    - **splunk_host.json**:  This file contains the values required to send to a Splunk HTTP Endpoint Collector API
     - **logstash.json**:  This file contains the values required to send to a Logstash input
     - **elasticsearch_host.json**:  This file contains the values required to send to the Elasticsearch document API
     - **influxdb.json**:  This file contains the values required to send to an InfluxDB HTTP API endpoint
@@ -62,7 +62,7 @@ Send Metrics to one or more metrics endpoints.  Valid values are:
  - logstash
  - elasticsearch
  - influxdb
- 
+
 
 ```sh
 $ avimetrics.py -m datadog -m graphite
@@ -169,7 +169,7 @@ EXAMPLE:
 
 ## splunk_host.json
 
-Define the values for sending values to Splunk HTTP Endpoint Collector.  The Splunk index data type is expected to be Metrics.
+Define the values for sending values to Splunk HTTP Endpoint Collector.
 
 EXAMPLE:
 
@@ -180,8 +180,11 @@ EXAMPLE:
     "hec_protocol":"https",
     "hec_port": 8088,
     "hec_token":"abcdefgh-ijkl-mnop-qrst-uvwxyz123456",
+    "_comment":"INDEX TYPE EVENT OR METRIC",
+    "index_type":"event",
     "index":"avimetrics"
     }
+
 }
 ```
 
@@ -288,6 +291,7 @@ $ docker run -d -e "EN_METRIC_ENDPOINT=graphite:datadog:appdynamics_http" --name
 - Virtual Server count per Service Engine
 - Service Engine count
 - Service Engine / Controller missed heartbeats
+- Service Engine connected state
 - Service Engine healthscore
 - Service Engine Virtual Service hosted used capacity
 - Statistics for each Service Engine
@@ -298,6 +302,7 @@ $ docker run -d -e "EN_METRIC_ENDPOINT=graphite:datadog:appdynamics_http" --name
     - se_stats.avg_cpu_usage
     - se_stats.avg_disk1_usage
     - se_stats.avg_mem_usage
+    - se_stats.avg_dynamic_mem_usage
     - se_stats.avg_persistent_table_usage
     - se_stats.avg_rx_bandwidth
     - se_if.avg_rx_bytes

--- a/monitoring/avimetrics script/avimetrics.py
+++ b/monitoring/avimetrics script/avimetrics.py
@@ -1,7 +1,7 @@
 #!/usr/bin/python
 
 
-version = 'v2019-02-04'
+version = 'v2019-03-20'
 
 #########################################################################################
 #                                                                                       #
@@ -300,13 +300,13 @@ class avi_metrics():
             return login
 
 
-    def avi_request(self,avi_api,tenant):
-        headers = ({"X-Avi-Tenant": "%s" %tenant, 'content-type': 'application/json'})
+    def avi_request(self,avi_api,tenant,api_version='17.2.1'):
+        headers = ({'X-Avi-Tenant': '%s' %tenant, 'content-type': 'application/json', 'X-Avi-Version': '%s' %api_version})
         return requests.get('https://%s/api/%s' %(self.avi_controller,avi_api), verify=False, headers = headers,cookies=dict(sessionid= self.login.cookies['sessionid']),timeout=50)
 
 
-    def avi_post(self,api_url,tenant,payload):
-        headers = ({"X-Avi-Tenant": "%s" %tenant, 'content-type': 'application/json','referer': 'https://%s' %self.avi_controller, 'X-CSRFToken': dict(self.login.cookies)['csrftoken']})
+    def avi_post(self,api_url,tenant,payload,api_version='17.2.1'):
+        headers = ({"X-Avi-Tenant": "%s" %tenant, 'content-type': 'application/json','referer': 'https://%s' %self.avi_controller, 'X-CSRFToken': dict(self.login.cookies)['csrftoken'],'X-Avi-Version':'%s' %api_version})
         cookies = dict(sessionid= self.login.cookies['sessionid'],csrftoken=self.login.cookies['csrftoken'])
         return requests.post('https://%s/api/%s' %(self.avi_controller,api_url), verify=False, headers = headers,cookies=cookies, data=json.dumps(payload),timeout=50)
 

--- a/monitoring/avimetrics script/metrics_endpoints.py
+++ b/monitoring/avimetrics script/metrics_endpoints.py
@@ -41,8 +41,8 @@ def send_value_graphite(endpoint_info, graphite_payload):
 
 
 
-#----- Send value to splunk HEC - destination a metric index
-def send_value_splunk(endpoint_info, splunk_payload):
+#----- Send value to splunk HEC - destination is a metric index
+def send_value_splunk_hec_metric(endpoint_info, splunk_payload):
     try:
         splunk_payload_template = {
             "source": "avi",
@@ -77,6 +77,45 @@ def send_value_splunk(endpoint_info, splunk_payload):
             resp = requests.post('%s://%s:%s/services/collector/event' %(endpoint_info['hec_protocol'], endpoint_info['server'], str(endpoint_info['hec_port'])) , verify=False, headers = headers, data=json.dumps(payload))
             if resp.status_code == 400:
                 print payload
+    except:
+        exception_text = traceback.format_exc()
+        print(str(datetime.now())+'   '+exception_text)
+        print entry
+
+
+
+
+#----- Send value to splunk HEC
+def send_value_splunk_hec(endpoint_info, splunk_payload):
+    try:
+        splunk_payload_template = {
+            #"source": "",
+            "time": "",
+            "host": "",
+            "index": endpoint_info['index'],
+            "sourcetype": "avi:metrics",
+            "event": {
+                "avi_controller": ""
+            }
+        }
+        hec_token = endpoint_info['hec_token']
+        headers = ({'Authorization': 'Splunk '+hec_token})
+        for entry in splunk_payload:
+            temp_entry = entry
+            keys_to_remove=["avicontroller","name_space"]
+            payload = splunk_payload_template.copy()
+            payload['host'] = temp_entry['avicontroller']
+            #payload['source'] = temp_entry['avicontroller']
+            payload['time'] = temp_entry['timestamp']
+            payload['sourcetype'] = 'avi:metrics'
+            payload['event']['avi_controller'] = temp_entry['avicontroller']
+            for k in keys_to_remove:
+                entry.pop(k, None)
+            for e in entry:
+                payload["event"][e]=entry[e]
+            resp = requests.post('%s://%s:%s/services/collector/event' %(endpoint_info['hec_protocol'], endpoint_info['server'], str(endpoint_info['hec_port'])) , verify=False, headers = headers, data=json.dumps(payload))
+            if resp.status_code == 400:
+                print resp.text
     except:
         exception_text = traceback.format_exc()
         print(str(datetime.now())+'   '+exception_text)
@@ -285,7 +324,10 @@ def send_metriclist_to_endpoint(endpoint_list, payload):
             if endpoint_info['type'] == 'graphite':
                 send_value_graphite(endpoint_info, payload)
             elif endpoint_info['type'] == 'splunk':
-                send_value_splunk(endpoint_info, payload)
+                if endpoint_info['index_type'].lower() == 'metric':
+                    send_value_splunk_hec_metric(endpoint_info, payload)
+                else:
+                    send_value_splunk_hec(endpoint_info, payload)
             elif endpoint_info['type'] == 'appdynamics_http':
                 send_value_appdynamics_http(endpoint_info, payload)
             elif endpoint_info['type'] == 'appdynamics_machine':
@@ -297,7 +339,7 @@ def send_metriclist_to_endpoint(endpoint_list, payload):
             elif endpoint_info['type'] == 'logstash':
                 send_value_logstash(endpoint_info, payload)
             elif endpoint_info['type'] == 'elasticsearch':
-                send_value_elasticsearch(endpoint_info, payload)                
+                send_value_elasticsearch(endpoint_info, payload)
             else:
                 print 'No sending data to any end point'
     except:

--- a/monitoring/avimetrics script/splunk_host.json
+++ b/monitoring/avimetrics script/splunk_host.json
@@ -4,6 +4,8 @@
     "hec_protocol":"https",
     "hec_port": 8088,
     "hec_token":"abcdefgh-ijkl-mnop-qrst-uvwxyz123456",
+    "_comment":"INDEX TYPE EVENT OR METRIC",
+    "index_type":"event",
     "index":"avimetrics"
     }
 


### PR DESCRIPTION
- allow for specifying splunk hec index type (event or metric)
- added api_version parameter to avi_request and avi_post methods (defaults to 17.2.1)