### PR TITLE
fix vsvip fqdn seach

### DIFF
--- a/cert_mgmt/letsencrypt_mgmt_profile.py
+++ b/cert_mgmt/letsencrypt_mgmt_profile.py
@@ -219,7 +219,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
         keyauthorization = "{0}.{1}".format(token, thumbprint)
 
         # Get VSVIPs/VSs, based on FQDN
-        rsp = _do_request_avi("vsvip/?fqdn={}".format(domain), "GET").json()
+        rsp = _do_request_avi("vsvip/?search=(fqdn,{})".format(domain), "GET").json()
         vhMode = False
         if debug:
             print ("Found {} matching VSVIP FQDNs".format(rsp["count"]))


### PR DESCRIPTION
use `/vsvip/?search=` instead of `/vsvip/?fqdn=` wich fail to find vsvip matching the fqdn
tested with 21.1.1