### PR TITLE
Updated LE script to 0.9.7

### DIFF
--- a/cert_mgmt/letsencrypt_mgmt_profile.py
+++ b/cert_mgmt/letsencrypt_mgmt_profile.py
@@ -133,7 +133,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
 
     apiHost = os.environ.get('DOCKER_GATEWAY', 'localhost')
     if debug:
-        print ("API Host is '{}'".format(apiHost))
+        print ("DEBUG: API Host is '{}'".format(apiHost))
     session = ApiSession(apiHost, user, password, tenant=tenant, api_version=api_version)
 
     def _do_request_avi(url, method, data=None, error_msg="Error"):
@@ -159,7 +159,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
 
     if os.path.exists(ACCOUNT_KEY_PATH):
         if debug:
-            print ("Reusing account key.")
+            print ("DEBUG: Reusing account key.")
     else:
         print ("Account key not found. Generating account key...")
         out = _cmd(["openssl", "genrsa", "4096"], err_msg="OpenSSL Error")
@@ -170,7 +170,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
     # We request the info here once, instead in the loop for each SAN entry below.
     if overwrite_vs != None:
         if debug:
-            print ("overwrite_vs is set to '{}'".format(overwrite_vs))
+            print ("DEBUG: overwrite_vs is set to '{}'".format(overwrite_vs))
         if overwrite_vs.lower().startswith('virtualservice-'):
             search_term = "uuid={}".format(overwrite_vs.lower())
         else:
@@ -234,7 +234,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
     # get the authorizations that need to be completed
     for auth_url in order['authorizations']:
         if debug:
-            print ("Authorization URL is: {}".format(auth_url))
+            print ("DEBUG: Authorization URL is: {}".format(auth_url))
 
         authorization, _, _ = _send_signed_request(auth_url, None, "Error getting challenges")
         domain = authorization['identifier']['value']
@@ -247,7 +247,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
 
         wellknown_url = "http://{0}/.well-known/acme-challenge/{1}".format(domain, token)
         if debug:
-            print ("Validation URL is: {}".format(wellknown_url))
+            print ("DEBUG: Validation URL is: {}".format(wellknown_url))
 
         vhMode = False
         # Check if we need to overwrite VirtualService UUID to something specific
@@ -256,7 +256,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
             # Get VSVIPs/VSs, based on FQDN
             rsp = _do_request_avi("vsvip/?search=(fqdn,{})".format(domain), "GET").json()
             if debug:
-                print ("Found {} matching VSVIP FQDNs".format(rsp["count"]))
+                print ("DEBUG: Found {} matching VSVIP FQDNs".format(rsp["count"]))
             if rsp["count"] == 0:
                 print ("Warning: Could not find a VSVIP with fqdn = {}".format(domain))
                 # As a fallback we search for VirtualHosting entries with that domain
@@ -268,7 +268,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
 
             rsp = _do_request_avi("virtualservice/?{}".format(search_term), "GET").json()
             if debug:
-                print ("Found {} matching VSs".format(rsp["count"]))
+                print ("DEBUG: Found {} matching VSs".format(rsp["count"]))
             if rsp['count'] == 0:
                 raise Exception("Could not find a VS with fqdn = {}".format(domain))
 
@@ -293,7 +293,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
             vs_uuid_parent = rsp["results"][0]["vh_parent_vs_ref"].split("/")[-1]
             vhRsp = _do_request_avi("virtualservice/?uuid={}".format(vs_uuid_parent), "GET").json()
             if debug:
-                print ("Parent VS of Child-VS is {} and found {} matches".format(vs_uuid_parent, vhRsp['count']))
+                print ("DEBUG: Parent VS of Child-VS is {} and found {} matches".format(vs_uuid_parent, vhRsp['count']))
             if vhRsp['count'] == 0:
                 raise Exception("Could not find parent VS {} of child VS UUID = {}".format(vs_uuid_parent, vs_uuid))
 
@@ -307,7 +307,7 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
             if service["port"] == 80 and not service["enable_ssl"]:
                 serving_on_port_80 = True
                 if debug:
-                    print ("VS serving on port 80")
+                    print ("DEBUG: VS serving on port 80")
                 break
 
         # Update VS

--- a/cert_mgmt/letsencrypt_mgmt_profile.py
+++ b/cert_mgmt/letsencrypt_mgmt_profile.py
@@ -162,14 +162,16 @@ def get_crt(user, password, tenant, api_version, csr, CA=DEFAULT_CA, disable_che
     # Check if we need to overwrite the VS UUID if it was specified
     # We request the info here once, instead in the loop for each SAN entry below.
     if overwrite_vs != None:
+        if debug:
+            print ("overwrite_vs is set to '{}'".format(overwrite_vs))
         if overwrite_vs.lower().startswith('virtualservice-'):
             search_term = "uuid={}".format(overwrite_vs.lower())
         else:
-            search_term = "name={}".format(urlparse.quote(overwrite_vs, safe=''))
+            search_term = "name={}".format(urllib.parse.quote(overwrite_vs, safe=''))
 
         overwrite_vs = _do_request_avi("virtualservice/?{}".format(search_term), "GET").json()
         if overwrite_vs['count'] == 0:
-            raise Exception("Could not find a VS with {}".format(search_term))
+            raise Exception("Could not find a VS with search {}".format(search_term))
 
     # parse account key to get public key
     print ("Parsing account key...")

--- a/cert_mgmt/letsencrypt_mgmt_profile.py
+++ b/cert_mgmt/letsencrypt_mgmt_profile.py
@@ -51,7 +51,7 @@
 ###
 '''
 
-import base64, binascii, datetime, hashlib, os, json, re, ssl, subprocess, sys, time
+import base64, binascii, hashlib, os, json, re, ssl, subprocess, time
 from urllib.parse import urlparse
 from urllib.request import urlopen, Request # Python 3
 from tempfile import NamedTemporaryFile

--- a/cert_mgmt/letsencrypt_mgmt_profile.py
+++ b/cert_mgmt/letsencrypt_mgmt_profile.py
@@ -508,7 +508,7 @@ def certificate_request(csr, common_name, kwargs):
 
     if letsencrypt_key != None:
         with open(ACCOUNT_KEY_PATH, 'w') as f:
-            f.write(letsencrypt_key.decode("utf-8"))
+            f.write(letsencrypt_key)
 
     # Create CSR temp file.
     csr_temp_file = NamedTemporaryFile(mode='w',delete=False)

--- a/cert_mgmt/letsencrypt_mgmt_profile.py
+++ b/cert_mgmt/letsencrypt_mgmt_profile.py
@@ -1,7 +1,7 @@
 '''
 ###
 # Name: letsencrypt_mgmt_profile.py
-# Version: 0.9.6
+# Version: 0.9.7
 # License: MIT
 #
 # Description -
@@ -60,7 +60,7 @@ from tempfile import NamedTemporaryFile
 
 from avi.sdk.avi_api import ApiSession
 
-VERSION = "0.9.6"
+VERSION = "0.9.7"
 
 DEFAULT_CA = "https://acme-v02.api.letsencrypt.org" # DEPRECATED! USE DEFAULT_DIRECTORY_URL INSTEAD
 DEFAULT_DIRECTORY_URL = "https://acme-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
Changes to 0.9.7:
* Removed unused python modules
* Updated argument description
* More debug logging, and added debug prefix to debug messages
* Fixed parsing for `overwrite_vs` when providing name (threw some exception)
* Removed `.decode()` when writing letsencrypt certificate as it was throwing an exception for me:
```
[2022-06-24 21:00:19,425] INFO [cs_container.executeScript:155] {'ExitCode': 1, 'stdout': 'Running version 0.9.7\nDebug enabled.\ndry_run is: False\ndisable_check is: True\ndirectory_url is https://acme-v02.api.letsencrypt.org/directory\n', 'stderr': 'Traceback (most recent call last):\n  File "/run/shm/cs/use_letsencrypt", line 561, in <module>\n    cert = certificate_request(csr, common_name, kwargs)\n  File "/run/shm/cs/use_letsencrypt", line 515, in certificate_request\n    f.write(letsencrypt_key.decode("utf-8"))\nAttributeError: \'str\' object has no attribute \'decode\'\nError in sys.excepthook:\nTraceback (most recent call last):\n  File "/usr/local/lib/python3.8/dist-packages/avi_traceback/avi_exception_hook.py", line 51, in avi_excepthook\n    os.makedirs(output_dir)\n  File "/usr/lib/python3.8/os.py", line 223, in makedirs\n    mkdir(name, mode)\nOSError: [Errno 30] Read-only file system: \'/var/lib/avi/python_crash\'\n\nOriginal exception was:\nTraceback (most recent call last):\n  File "/run/shm/cs/use_letsencrypt", line 561, in <module>\n    cert = certificate_request(csr, common_name, kwargs)\n  File "/run/shm/cs/use_letsencrypt", line 515, in certificate_request\n    f.write(letsencrypt_key.decode("utf-8"))\nAttributeError: \'str\' object has no attribute \'decode\'\n'}
```

Script tested with 21.1.4-2p3.