### PR TITLE
Add compute.machineTypes.list to GCP service_engine_project_role

### DIFF
--- a/gcp/roles/service_engine_project_role.yaml
+++ b/gcp/roles/service_engine_project_role.yaml
@@ -28,6 +28,7 @@ includedPermissions:
 - compute.instances.setTags
 - compute.instances.use
 - compute.machineTypes.get
+- compute.machineTypes.list
 - compute.regionOperations.get
 - compute.regions.get
 - compute.regions.list


### PR DESCRIPTION
The permission 'compute.machineTypes.list' is necessary for the controller to populate the instance flavor drop-down when editing a service engine group.