### PR TITLE
Updated CAP aws controller deployment playbook with key pair and new ec2_instance module  

### DIFF
--- a/ansible/customer-acceleration/aws/create_cluster/README.md
+++ b/ansible/customer-acceleration/aws/create_cluster/README.md
@@ -8,7 +8,7 @@ AWS Playbooks use BOTO and aws credentials file
 
 Install BOTO:
 ```bash
-pip install boto
+pip3 install boto3
 ```
 
 Once Installed setup your AWS Credentials
@@ -21,6 +21,17 @@ vi ~/.aws/credentials
 Add the following lines with your details
 ```bash
 [default]
-aws_access_key_id = <YOUR_ACCESS_KEY>
-aws_secret_access_key = <YOUR_SECRET_KEY>
+AWS_ACCESS_KEY_ID = <YOUR_ACCESS_KEY>
+AWS_SECRET_ACCESS_KEY = <YOUR_SECRET_KEY>
+AWS_SESSION_TOKEN = <YOUR_SESSION_TOKEN>
+
+The ansible playbook has been tested under Avitools container version 22.1.1 with the following software packages:
+Ansible = 2.13.2
+amazon.aws = 4.1.0
+vmware.alb = 22.1.1
+Python3 = 3.8.10
+boto3 = 1.24.34
+
+You can retrieve the container:
+docker pull avinetworks/avitools:22.1.1
 ```

--- a/ansible/customer-acceleration/aws/create_cluster/deploy_controller_cluster.yml
+++ b/ansible/customer-acceleration/aws/create_cluster/deploy_controller_cluster.yml
@@ -1,65 +1,81 @@
 - hosts: localhost
-  connection: local
   gather_facts: no
   vars_files:
-     variables.yml
+    variables.yml
   vars:
+    ansible_ssh_private_key_file: "{{ EC2_PRIVATE_KEY }}"
+    ansible_host_key_checking : false
     controller_configuration:
       - vm_name: "{{ CONTROLLER_NAME_1 }}"
       - vm_name: "{{ CONTROLLER_NAME_2 }}"     
       - vm_name: "{{ CONTROLLER_NAME_3 }}"
   tasks:
   - name: "Create EC2 Instance"
-    ec2:
-      group: "{{ EC2_SECURITY_GROUP }}"
+    amazon.aws.ec2_instance:
+      name: "{{ item.vm_name }}" 
+      security_group: "{{ EC2_SECURITY_GROUP }}"
       instance_type: "{{ EC2_INSTANCE_TYPE }}"
-      image: "{{ EC2_IMAGE_ID }}"
-      monitoring: "{{ EC2_MONITOR }}"
+      instance_role: "{{ EC2_IAM_INSTANCE_PROFILE | default(omit) }}"
+      image_id: "{{ EC2_IMAGE_ID }}"
+      detailed_monitoring: "{{ EC2_MONITOR }}"
       key_name: "{{ EC2_KEY_NAME }}"
-      vpc_subnet_id: "{{ EC2_SUBNET_ID }}"
       region: "{{ EC2_REGION }}"
-      assign_public_ip: "{{ EC2_ASSIGN_PUBLIC_IP }}"
-      instance_tags: 
-        Name: "{{ item.vm_name }}"
+      vpc_subnet_id: "{{ EC2_SUBNET_ID }}"
+      network:
+        assign_public_ip: "{{ EC2_ASSIGN_PUBLIC_IP }}"
+        delete_on_termination: yes
       wait: yes
-      instance_profile_name: "{{ EC2_IAM_INSTANCE_PROFILE | default(omit) }}"
-      count_tag:
-        Name: "{{ item.vm_name }}"
       exact_count: 1
+      termination_protection: yes
       volumes:
       - device_name: /dev/sda1
-        volume_size: "{{ EC2_ROOT_VOLUME_SIZE }}"
-        delete_on_termination: true
-        termination_protection: yes
+        ebs:
+          volume_size: "{{ EC2_ROOT_VOLUME_SIZE }}"
+          delete_on_termination: true      
     with_items: "{{ controller_configuration }}"
     register: controller_fact
+
+  # in amazon.aws == 4.1.0; when creating EC2 instance, 
+  # public_ip_address attribute randomly missed in the controller_fact variable
+  # even though public ip is assigned to the instance
+  # so created a task to retrieve it after createion   
+  - name: "Retrieve EC2 Instances"
+    amazon.aws.ec2_instance_info:
+      region: "{{ EC2_REGION }}"
+      instance_ids:
+        - "{{ item.instances[0].instance_id }}"
+    with_items: "{{ controller_fact.results }}"  
+    register: instances    
+  - debug:
+      var: instances
+
   - set_fact:
-      CONTROLLER_CLUSTER_IP: "{{ controller_fact.results[0].tagged_instances[0].public_ip }}"
-  - name: Add the newly created EC2 instance(s) host group
-    lineinfile: 
-      dest: variables.yml
-      insertafter: "# IP for Avi Controller MGMT" 
-      line: "{{ 'CONTROLLER_CLUSTER_IP: '+ CONTROLLER_CLUSTER_IP }}"
-      state: present
+      CONTROLLER_CLUSTER_IP: "{{ instances.results[0].instances[0].public_ip_address }}"
+
   - name: Verify All controllers are online
     uri:
       validate_certs: false
-      url: "https://{{ item.tagged_instances[0].public_ip }}/api/initial-data"
+      url: "https://{{ item.instances[0].public_ip_address }}/api/initial-data"
       method: GET
       status_code: 200
     register: result
     until: result.status == 200
     retries: 600
     delay: 10
-    with_items: "{{ controller_fact.results }}"
-  - name: Change admin default password
-    avi_useraccount:
-      controller: "{{ CONTROLLER_CLUSTER_IP }}"
-      username: "{{ AVI_CREDENTIALS.username }}"
-      password: "{{ AVI_CREDENTIALS.password }}"
-      api_version: "{{ AVI_CREDENTIALS.api_version }}"
-      old_password: "{{ OLD_PASSWORD }}"
+    with_items: "{{ instances.results }}"
+
+  # init Avi admin account    
+  - name: "Initialize Avi admin user" 
+    delegate_to: "{{ item.instances[0].public_ip_address }}"
+    remote_user: "{{ AVI_CREDENTIALS.username }}"
+    command:  sudo /opt/avi/scripts/initialize_admin_user.py --password "{{ AVI_CREDENTIALS.password }}"
+    register: result
+    until: result.stdout_lines[0] | regex_search('sync_linux_one_user') and result.stdout_lines[-1] == "Password reset complete"
     ignore_errors: yes
+    retries: 600
+    delay: 10    
+    with_items: "{{ instances.results }}" 
+
   - set_fact:
       dns_list: "{{ dns_list | default([]) + [{'type': 'V4', 'addr': dserver }] }}"
     loop: "{{ DNS_SERVERS }}"
@@ -92,25 +108,28 @@
       name: Backup-Configuration
       backup_passphrase: "{{ BACKUP_PASSPHRASE }}"
       upload_to_remote_host: false
-  - name: Cloud Cluster Setup
+ 
+  - name: Avi Cluster Setup
     avi_cluster:
       controller: "{{ CONTROLLER_CLUSTER_IP }}"
       username: "{{ AVI_CREDENTIALS.username }}"
       password: "{{ AVI_CREDENTIALS.password }}"
       api_version: "{{ AVI_CREDENTIALS.api_version }}"
       nodes:
-          - name: "{{ controller_fact.results[0].tagged_instances[0].private_ip }}" 
-            ip:
-              type: V4
-              addr: "{{ controller_fact.results[0].tagged_instances[0].private_ip }}"
-          - name: "{{ controller_fact.results[1].tagged_instances[0].private_ip  }}"
-            ip:
-              type: V4
-              addr: "{{ controller_fact.results[1].tagged_instances[0].private_ip  }}"
-          - name: "{{ controller_fact.results[2].tagged_instances[0].private_ip }}"
-            ip:
-              type: V4
-              addr: "{{ controller_fact.results[2].tagged_instances[0].private_ip }}"
+        - name: "{{ instances.results[0].item.item.vm_name }}" 
+          ip:
+            type: V4
+            addr: "{{ instances.results[0].instances[0].private_ip_address }}"
+        - name: "{{ instances.results[1].item.item.vm_name  }}"
+          ip:
+            type: V4
+            addr: "{{ instances.results[1].instances[0].private_ip_address  }}"
+          password: "{{ AVI_CREDENTIALS.password }}"
+        - name: "{{ instances.results[2].item.item.vm_name }}"
+          ip:
+            type: V4
+            addr: "{{ instances.results[2].instances[0].private_ip_address }}"
+          password: "{{ AVI_CREDENTIALS.password }}"
       name: cluster01
       tenant_uuid: "admin"
   - name: Verify Cluster Completed

--- a/ansible/customer-acceleration/aws/create_cluster/variables.yml
+++ b/ansible/customer-acceleration/aws/create_cluster/variables.yml
@@ -1,10 +1,11 @@
 # --------------------------------------------------------------------
 # Prepare your Environment:
-# pip install boto
+# pip3 install boto3
 # Edit ~/.aws/credentials and add lines below:
 # [default]
-# aws_access_key_id = YOUR_ACCESS_KEY
-# aws_secret_access_key = YOUR_SECRET_KEY
+# AWS_ACCESS_KEY_ID = <YOUR_ACCESS_KEY>
+# AWS_SECRET_ACCESS_KEY = <YOUR_SECRET_KEY>
+# AWS_SESSION_TOKEN = <YOUR_SESSION_TOKEN>
 # --------------------------------------------------------------------
 
 # --------------------------------------------------------------------
@@ -14,44 +15,42 @@
 
 # Controller Credentials
 AVI_CREDENTIALS:
-  controller: "{{ CONTROLLER_CLUSTER_IP }}" # This can be either cluster ip or the ip of the leader controller.
   username: "admin"
   password: "<password>"
-  api_version: "20.1.4"
+  api_version: "21.1.5" # This should match the Avi version you're installing.
 
 # --------------------------------------------------------------------
 # Required Variables / Controller Deployments
-# Description: This are the main variables required for controller deployments.
+# Description: These are the main variables required for controller deployments.
 # --------------------------------------------------------------------
 # Controller Name
 CONTROLLER_NAME_1: "nsxalb-01"
 CONTROLLER_NAME_2: "nsxalb-02"
 CONTROLLER_NAME_3: "nsxalb-03"
 
-# Controller Default Password
-OLD_PASSWORD: "<controller default password>" #Found on download image page
-
 # Controller Configuration Details
 DNS_SERVERS: [ 	8.8.8.8 ]
 NTP_SERVERS: [ '0.us.pool.ntp.org', '1.us.pool.ntp.org', '3.us.pool.ntp.org' ]
 NTP_TYPE: "DNS"  #If servers are hostname use type "DNS", if IP use type "V4"
 ADMIN_EMAIL: test_user@internal.lab   
-BACKUP_PASSPHRASE: "1234567890"
+BACKUP_PASSPHRASE: "Your_Backup_PASSPHRASE"
 
 # --------------------------------------------------------------------
-# Enviroment Variables / Controller Deployments
-# Description: You only have to apply variables on the installation type you desire.
+# EC2 Variables / Controller Deployments
+# Description: These are the variables required for controller EC2 instance deployments.
+# Before creating controller EC2 instances, you must create a key pair and then download the private key to a secure location
+# The key pair is used to initialize Avi admin credential
 # --------------------------------------------------------------------
 
 # AWS Variables
-EC2_SECURITY_GROUP: ag_avi_sec_group
-EC2_INSTANCE_TYPE: c4.4xlarge
-EC2_IMAGE_ID: ami-0822ac66b62a893cc
+EC2_SECURITY_GROUP: <YOUR_PREDIFINED_SECURITY_GROUP>
+EC2_INSTANCE_TYPE: <SIZE_OF_YOUR_CHOICE> # It could be c4.4xlarge, m5.2xlarge, etc.
+EC2_IMAGE_ID: <AVI_EC2_AMI_ID> # Like ami-0822ac66b62a893cc for 21.1.4
 EC2_MONITOR: no
-EC2_SUBNET_ID: subnet-06d88a4c
-EC2_REGION: us-east-1
-EC2_ROOT_VOLUME_SIZE: 256
-EC2_PREFIX: avictrl
+EC2_SUBNET_ID: <YOUR_SUBNET_ID> # Something like subnet-06d88a4c 
+EC2_REGION: <YOUR_REGION_OF_CHOICE>
+EC2_ROOT_VOLUME_SIZE: <DISK_SIZE_IN_GB> # Something like 256, depending on the controller size of your choice
 EC2_KEY_NAME: <key_pair_name>
+EC2_PRIVATE_KEY: <PRIVATE_KEY_LOCATION>
 EC2_IAM_INSTANCE_PROFILE: "AviController-Refined-Role"
 EC2_ASSIGN_PUBLIC_IP: yes


### PR DESCRIPTION
Updated the playbook to use key pair to initialize admin password; 
aws.ec2 module is removed after version 4.0.0; updated the playbook with the new aws.ec2_instance module