### PR TITLE
Updated monitoring readme and sample prometheus scrape file

### DIFF
--- a/monitoring_tools/grafana/README.md
+++ b/monitoring_tools/grafana/README.md
@@ -1,0 +1,17 @@
+This folder contains pre-built grafana dashboards for various endpoints which can be connected to Grafana for monitoring VMware Avi Load Balancer. 
+
+## graphite
+
+- The sample dashboards can be imported in grafana when using graphite db along with the metrics collection script
+
+## influxdb
+
+- The sample dashboards can be imported in grafana when using influxdb along with the metrics collection script
+
+## prometheus
+
+- The sameple dashboards can be imported in grafana when using prometheus as an endpoint. 
+- Prometheus should already be integrated with VMware Avi for metrics collection using avi-api-proxy container. 
+  Detailed steps are available at : https://docs.vmware.com/en/VMware-NSX-Advanced-Load-Balancer/22.1/Monitoring_Operability_Guide/GUID-4FA0F81D-CA6D-4502-A1D9-2CB0ACFB6D6A.html
+
+- There is a sample yaml config (prometheus_sample_config.yml) which can be used for prometheus metric scrape configuration 

--- a/monitoring_tools/grafana/README.md
+++ b/monitoring_tools/grafana/README.md
@@ -1,8 +1,8 @@
-This folder contains pre-built grafana dashboards for various endpoints which can be connected to Grafana for monitoring VMware Avi Load Balancer. 
+This folder contains pre-built grafana dashboards for various endpoints which can be connected to grafana for monitoring VMware Avi Load Balancer. 
 
 ## graphite
 
-- The sample dashboards can be imported in grafana when using graphite db along with the metrics collection script
+- The sample dashboards can be imported in grafana when using graphitedb along with the metrics collection script
 
 ## influxdb
 
@@ -10,8 +10,9 @@ This folder contains pre-built grafana dashboards for various endpoints which ca
 
 ## prometheus
 
-- The sameple dashboards can be imported in grafana when using prometheus as an endpoint. 
-- Prometheus should already be integrated with VMware Avi for metrics collection using avi-api-proxy container. 
+- The sample dashboards can be imported in grafana when using prometheus as an endpoint. 
+- prometheus should already be integrated with VMware Avi for metrics collection using avi-api-proxy container. 
   Detailed steps are available at : https://docs.vmware.com/en/VMware-NSX-Advanced-Load-Balancer/22.1/Monitoring_Operability_Guide/GUID-4FA0F81D-CA6D-4502-A1D9-2CB0ACFB6D6A.html
+- avi api proxy is available to download at https://github.com/avinetworks/devops/tree/master/tools/avi-api-proxy
 
 - There is a sample yaml config (prometheus_sample_config.yml) which can be used for prometheus metric scrape configuration 

--- a/monitoring_tools/grafana/prometheus/prometheus_sample_config.yml
+++ b/monitoring_tools/grafana/prometheus/prometheus_sample_config.yml
@@ -1,0 +1,123 @@
+global:
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  evaluation_interval: 15s
+alerting:
+  alertmanagers:
+  - follow_redirects: true
+    scheme: http
+    timeout: 10s
+    api_version: v2
+    static_configs:
+    - targets: []
+scrape_configs:
+- job_name: prometheus
+  honor_timestamps: true
+  scrape_interval: 15s
+  scrape_timeout: 10s
+  metrics_path: /metrics
+  scheme: http
+  follow_redirects: true
+  static_configs:
+  - targets:
+    - localhost:9090
+## Avi controller scrape configs 
+- job_name: avi_api_vs1  ## Job name
+  honor_timestamps: true
+  params:
+    tenant:
+    - admin   ## Tenant Names to be mentioned comma separated 
+  scrape_interval: 1m ## scrape interval
+  scrape_timeout: 45s ## scrape timeout
+  metrics_path: /api/analytics/prometheus-metrics/virtualservice ## VirtualService metrics collected
+  scheme: http
+  follow_redirects: true
+  metric_relabel_configs:  ## config to replace the controller instance name
+  - source_labels: [instance]
+    separator: ;
+    regex: (.*)
+    target_label: instance
+    replacement: avi-demo-controller ## replacement name to be used
+    action: replace
+  static_configs:
+  - targets:
+    - 172.17.0.2:8080 ## avi-api-proxy container ip address and port 
+- job_name: avi_api_se_specific
+  honor_timestamps: true
+  params:
+    metric_id:
+    - se_if.avg_bandwidth,se_if.avg_rx_pkts,se_if.avg_rx_bytes,se_if.avg_tx_bytes,se_if.avg_tx_pkts  ## Specific SE metrics which are collected
+    tenant:
+    - admin,Demo
+  scrape_interval: 1m
+  scrape_timeout: 45s
+  metrics_path: /api/analytics/prometheus-metrics/serviceengine   ## Metrics path for  Service Engine
+  scheme: http
+  follow_redirects: true
+  metric_relabel_configs:
+  - source_labels: [instance]
+    separator: ;
+    regex: (.*)
+    target_label: instance
+    replacement: avi-demo-controller
+    action: replace
+  static_configs:
+  - targets:
+    - 172.17.0.2:8080
+- job_name: avi_api_se
+  honor_timestamps: true
+  params:
+    tenant:
+    - admin
+  scrape_interval: 1m
+  scrape_timeout: 45s
+  metrics_path: /api/analytics/prometheus-metrics/serviceengine ## Metrics path for  Service Engine
+  scheme: http
+  follow_redirects: true
+  metric_relabel_configs:
+  - source_labels: [instance]
+    separator: ;
+    regex: (.*)
+    target_label: instance
+    replacement: avi-demo-controller
+    action: replace
+  static_configs:
+  - targets:
+    - 172.17.0.2:8080
+- job_name: avi_api_pool
+  honor_timestamps: true
+  params:
+    tenant:
+    - admin
+  scrape_interval: 1m
+  scrape_timeout: 45s
+  metrics_path: /api/analytics/prometheus-metrics/pool  ## Metrics path for Pool  
+  scheme: http
+  follow_redirects: true
+  metric_relabel_configs:
+  - source_labels: [instance]
+    separator: ;
+    regex: (.*)
+    target_label: instance
+    replacement: avi-demo-controller
+    action: replace
+  static_configs:
+  - targets:
+    - 172.17.0.2:8080
+- job_name: avi_api_controller
+  honor_timestamps: true
+  scrape_interval: 1m
+  scrape_timeout: 45s
+  metrics_path: /api/analytics/prometheus-metrics/controller  ## Metrics path for Avi Controller 
+  scheme: http
+  follow_redirects: true
+  metric_relabel_configs:
+  - source_labels: [instance]
+    separator: ;
+    regex: (.*)
+    target_label: instance
+    replacement: avi-demo-controller
+    action: replace
+  static_configs:
+  - targets:
+    - 172.17.0.2:8080

--- a/monitoring_tools/grafana/prometheus/prometheus_sample_config.yml
+++ b/monitoring_tools/grafana/prometheus/prometheus_sample_config.yml
@@ -48,7 +48,7 @@ scrape_configs:
     metric_id:
     - se_if.avg_bandwidth,se_if.avg_rx_pkts,se_if.avg_rx_bytes,se_if.avg_tx_bytes,se_if.avg_tx_pkts  ## Specific SE metrics which are collected
     tenant:
-    - admin,Demo
+    - admin
   scrape_interval: 1m
   scrape_timeout: 45s
   metrics_path: /api/analytics/prometheus-metrics/serviceengine   ## Metrics path for  Service Engine


### PR DESCRIPTION
Hi Nick, 
I have updated the readme.md under monitoring_tools/grafana mentioning about the different dashboards. 
Also while integrating prometheus using the avi-api-proxy we need to use the scrape config for the metrics , so that the prometheus dashboards can be used. I have tested out this scrape config in the lab, this also talks about the different configurable configs and when to be used in the yaml.
Please review and merge this changes