### PR TITLE
AV-207716: Clear albservices job in clean up registration script

### DIFF
--- a/tools/misc/cleanup_registration_21_1_3_or_later.py
+++ b/tools/misc/cleanup_registration_21_1_3_or_later.py
@@ -71,6 +71,7 @@ if __name__ == '__main__':
          print("Controller version is less than 21.1.3, no license clean up needed.")
     else:
         from api.models import LicenseStatus
+        from api.models import ALBServicesJob
 
         # Delete license status object
         for ls in LicenseStatus.objects.all():
@@ -91,8 +92,14 @@ if __name__ == '__main__':
                 controllerLicense.save_pb()
 
                 ds.save('controllerlicense', controllerLicense.json_data['uuid'], controllerLicense.protobuf(), None)
-
         print("Controller's license state is cleared.")
+
+        # Delete albservices job from the datastore and database
+        for albservicesJob in ALBServicesJob.objects.all():
+            albservicesJob.delete()
+            ds.delete('albservicesjob', albservicesJob.json_data['uuid'])
+        print("Controller's albservice jobs are cleared.")
+        
        
     os.system("systemctl restart license_mgr")
     os.system("systemctl restart portalconnector")


### PR DESCRIPTION
**Work done:**
* If controller version is less than 22.1.3 remove albservices job.


**Tests:**
* Tested on 31.1.1 controller and the script cleared the two albservices job.
```shell
admin@jyellapu-ctrl49:~$ sudo python3 scripts.py
[sudo] password for admin:
Controller's registration state is cleared.
Controller version is : 31.1.1
Controller's license state is cleared.
AlbserviceJobs are cleared.
``` 