### PR TITLE
Adding the missing IAM XAccess Policy to github repo

### DIFF
--- a/tools/aws/iam-policies/avicontroller-iam-XAccess-policy.json
+++ b/tools/aws/iam-policies/avicontroller-iam-XAccess-policy.json
@@ -1,0 +1,29 @@
+{
+    "Version": "2012-10-17",
+    "Statement": [
+        {
+            "Sid": "Stmt1450417666000",
+            "Effect": "Allow",
+            "Action": [
+                "iam:GetPolicy",
+                "iam:GetPolicyVersion",
+                "iam:GetRole",
+                "iam:GetRolePolicy",
+                "iam:ListAttachedRolePolicies",
+                "iam:ListPolicies",
+                "iam:ListRolePolicies",
+                "iam:ListRoles",
+                "iam:ListAccountAliases",
+                "iam:ListAttachedUserPolicies",
+                "iam:ListAttachedGroupPolicies",
+                "iam:GetUserPolicy",
+                "iam:GetGroupPolicy",
+                "iam:ListUserPolicies",
+                "iam:ListgroupPolicies"
+            ],
+            "Resource": [
+                "*"
+            ]
+        }
+    ]
+}


### PR DESCRIPTION
The IAM XAccess Policy required for Assume role during Avi AWS setup was missing - 
https://docs.vmware.com/en/VMware-NSX-Advanced-Load-Balancer/22.1/Installation_Guide/GUID-5185B3DB-C463-49D8-B4D6-03D4305250AD.html

https://avinetworks.com/docs/latest/aws-cross-account-assumerole-support/