### PR TITLE
Update service_engine_project_role.yaml

### DIFF
--- a/tools/gcp/roles/service_engine_project_role.yaml
+++ b/tools/gcp/roles/service_engine_project_role.yaml
@@ -28,6 +28,7 @@ includedPermissions:
 - compute.instances.setTags
 - compute.instances.use
 - compute.machineTypes.get
+- compute.machineTypes.list
 - compute.regionOperations.get
 - compute.regions.get
 - compute.regions.list


### PR DESCRIPTION
compute.MachineType.list was missing causing failures on list instance types on GCP SE configuration